### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-BEGIN { @*INC.unshift('lib') }
+use lib 'lib';
 
 use GD::Raw;
 ok 1, "GD::Raw loaded";

--- a/t/01-create-and-load.t
+++ b/t/01-create-and-load.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-BEGIN { @*INC.unshift('lib') }
+use lib 'lib';
 
 use GD::Raw;
 plan 7;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.